### PR TITLE
support llong TTL in cron

### DIFF
--- a/samples/cloudformation-stack-ttl/templates/cloudformation-stack-ttl.yaml
+++ b/samples/cloudformation-stack-ttl/templates/cloudformation-stack-ttl.yaml
@@ -138,7 +138,11 @@ Resources:
               delete_at_time = datetime.now() + timedelta(minutes=int(ttl))
               hh = delete_at_time.hour
               mm = delete_at_time.minute
-              cron_exp = "cron({} {} * * ? *)".format(mm, hh)
+              yyyy = delete_at_time.year
+              month = delete_at_time.month
+              dd = delete_at_time.day
+              # minutes hours day month day-of-week year
+              cron_exp = "cron({} {} {} {} ? {})".format(mm, hh, dd, month, yyyy)
               return cron_exp
           
           def handler(event, context):


### PR DESCRIPTION
The cron expression was not supportive of durations that crossed a day boundary

*Issue #, if available:*

*Description of changes:*
The cron expression is currently only using the hour and minute of the calculated time stamp. 
Which means that the TTL is at most 24 hours, or 1440 minutes. 
The change allows the expiration to be of durations longer than 24 hours, by setting the year, month, and day in the cron expression. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
