### PR TITLE
Fix #10 Updated the way requests is imported

### DIFF
--- a/samples/cloudformation-cross-account/functions/source/CfnStackAssumeRole/lambda_function.py
+++ b/samples/cloudformation-cross-account/functions/source/CfnStackAssumeRole/lambda_function.py
@@ -3,7 +3,7 @@ import random
 import string
 import logging
 import threading
-from botocore.vendored import requests
+import requests
 import json
 from botocore.credentials import (
     AssumeRoleCredentialFetcher,

--- a/samples/cloudformation-cross-account/functions/source/CfnStackAssumeRole/requirements.txt
+++ b/samples/cloudformation-cross-account/functions/source/CfnStackAssumeRole/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Fixes #10 

Botocore has deprecated the vendored version:
https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/

If this is not merged, deployments in recent python runtimes will cause
failures.